### PR TITLE
updating max tokens | removing stop words in chat-tempalte evals

### DIFF
--- a/lm-eval_tasks/babi_tasks/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/babi_tasks/chat_zero-shot_a-vert/_default_template_yaml
@@ -7,9 +7,7 @@ doc_to_text: "Passage: {{passage}}Question: {{question}}"
 doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 generation_kwargs:
-  max_gen_toks: 7000
-  until:
-    - "</s>"
+  max_gen_toks: 25000
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/babi_tasks/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/babi_tasks/chat_zero-shot_a-vert/_default_template_yaml
@@ -8,6 +8,7 @@ doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/babisteps/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/babisteps/chat_zero-shot_a-vert/_default_template_yaml
@@ -8,11 +8,7 @@ doc_to_text: !function utils.doc_to_text
 doc_to_target: answer
 process_results: !function utils.process_results
 generation_kwargs:
-  max_gen_toks: 3096
-  until:
-    - "\n\n\n\n"
-    - "## World enumeration ##"
-    - "## Story ##"
+  max_gen_toks: 25000
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/babisteps/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/babisteps/chat_zero-shot_a-vert/_default_template_yaml
@@ -9,6 +9,7 @@ doc_to_target: answer
 process_results: !function utils.process_results
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/bbh_split/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/bbh_split/chat_zero-shot_a-vert/_default_template_yaml
@@ -12,9 +12,7 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 generation_kwargs:
-  max_gen_toks: 7000
-  until:
-    - "</s>"
+  max_gen_toks: 25000
   do_sample: false
   temperature: 0.0
 filter_list:

--- a/lm-eval_tasks/bbh_split/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/bbh_split/chat_zero-shot_a-vert/_default_template_yaml
@@ -13,6 +13,7 @@ metric_list:
     higher_is_better: true
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
   do_sample: false
   temperature: 0.0
 filter_list:

--- a/lm-eval_tasks/gpqa_subtask/chat_zero-shot_a-vert/_gpqa_subtask_chat_yaml
+++ b/lm-eval_tasks/gpqa_subtask/chat_zero-shot_a-vert/_gpqa_subtask_chat_yaml
@@ -13,10 +13,7 @@ filter_list:
       - function: take_first
 num_fewshot: 0
 generation_kwargs:
-  max_gen_toks: 7000
-  until:
-    - "</s>"
-    - "<|im_end|>"
+  max_gen_toks: 25000
   temperature: 0.0
 metadata:
   version: 1.0

--- a/lm-eval_tasks/gpqa_subtask/chat_zero-shot_a-vert/_gpqa_subtask_chat_yaml
+++ b/lm-eval_tasks/gpqa_subtask/chat_zero-shot_a-vert/_gpqa_subtask_chat_yaml
@@ -14,6 +14,7 @@ filter_list:
 num_fewshot: 0
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
   temperature: 0.0
 metadata:
   version: 1.0

--- a/lm-eval_tasks/gsm8k_chat/gsm8k-chat-zeroshot.yaml
+++ b/lm-eval_tasks/gsm8k_chat/gsm8k-chat-zeroshot.yaml
@@ -11,6 +11,7 @@ doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
   do_sample: false
   temperature: 0.0
 num_fewshot: 0

--- a/lm-eval_tasks/gsm8k_chat/gsm8k-chat-zeroshot.yaml
+++ b/lm-eval_tasks/gsm8k_chat/gsm8k-chat-zeroshot.yaml
@@ -10,10 +10,7 @@ doc_to_text: "{{question}}"
 doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 generation_kwargs:
-  max_gen_toks: 7000
-  until:
-    - "</s>"
-    - "<|im_end|>"
+  max_gen_toks: 25000
   do_sample: false
   temperature: 0.0
 num_fewshot: 0

--- a/lm-eval_tasks/mmlu_chat/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/mmlu_chat/chat_zero-shot_a-vert/_default_template_yaml
@@ -7,6 +7,7 @@ doc_to_target: "{{['A', 'B', 'C', 'D'][answer]}}"
 process_results: !function utils.process_results
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/mmlu_chat/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/mmlu_chat/chat_zero-shot_a-vert/_default_template_yaml
@@ -6,9 +6,7 @@ doc_to_text: "{{question.strip()}}\nA. {{choices[0]}}\nB. {{choices[1]}}\nC. {{c
 doc_to_target: "{{['A', 'B', 'C', 'D'][answer]}}"
 process_results: !function utils.process_results
 generation_kwargs:
-  max_gen_toks: 7000
-  until:
-    - "</s>"
+  max_gen_toks: 25000
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/mmlu_pro_categories/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/mmlu_pro_categories/chat_zero-shot_a-vert/_default_template_yaml
@@ -6,9 +6,7 @@ doc_to_text: !function utils.doc_to_text
 doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 generation_kwargs:
-  max_gen_toks: 7000
-  until:
-    - "</s>"
+  max_gen_toks: 25000
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/mmlu_pro_categories/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/mmlu_pro_categories/chat_zero-shot_a-vert/_default_template_yaml
@@ -7,6 +7,7 @@ doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
 filter_list:
   - name: pass_all
     filter:

--- a/lm-eval_tasks/reasoning_gym/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/reasoning_gym/chat_zero-shot_a-vert/_default_template_yaml
@@ -10,8 +10,6 @@ metric_list:
     higher_is_better: true
 generation_kwargs:
   max_gen_toks: 25000
-  until:
-    - "</s>"
   do_sample: false
   temperature: 0.0
 filter_list:

--- a/lm-eval_tasks/reasoning_gym/chat_zero-shot_a-vert/_default_template_yaml
+++ b/lm-eval_tasks/reasoning_gym/chat_zero-shot_a-vert/_default_template_yaml
@@ -10,6 +10,7 @@ metric_list:
     higher_is_better: true
 generation_kwargs:
   max_gen_toks: 25000
+  until: null
   do_sample: false
   temperature: 0.0
 filter_list:


### PR DESCRIPTION
- Removed stopwords: The chat-template tasks had stopwords, which should not be there (only valid in completions tasks)
- Increased the max tokens for all tasks to 25K tokens. Current models have much more context length and many of them are thinking, we need to allow them to go through their reasoning.